### PR TITLE
Added 4.1.0 as supported version

### DIFF
--- a/docs/configuration/vapor/basic.md
+++ b/docs/configuration/vapor/basic.md
@@ -30,6 +30,8 @@ Currently supported versions:
 
 - 4.0.0
 
+- 4.1.0
+
 ## Adding cURL HTTP/2 Support
 
 Currently cURL with HTTP/2 is in beta support, so it's optional to add. This will be default at a later point.


### PR DESCRIPTION
Is Swift 3 still the default ?