### PR TITLE
Update header href to homepage

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -63,7 +63,7 @@
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
         
-          <a href="." title="Vapor Cloud Docs" class="md-logo md-header-nav__button">
+          <a href="/" title="Vapor Cloud Docs" class="md-logo md-header-nav__button">
             <img src="./images/white-cloud-icon.svg" width="24" height="24">
           </a>
         


### PR DESCRIPTION
The link in header redirecting to `.` (http://0.0.0.0:8080/) and not `/` Propose change to fix link to point to the homepage of the website.