### PR TITLE
Updating supported swift versions list

### DIFF
--- a/docs/configuration/vapor/basic.md
+++ b/docs/configuration/vapor/basic.md
@@ -30,6 +30,10 @@ Currently supported versions:
 
 - 4.0.0
 
+- 4.1.0
+
+- 4.2.0
+
 ## Adding cURL HTTP/2 Support
 
 Currently cURL with HTTP/2 is in beta support, so it's optional to add. This will be default at a later point.


### PR DESCRIPTION
This PR adds Swift 4.1.0 and 4.2.0 as supported versions in the docs. 4.1.0 is supported, for example it is used in [Vapor TIL app](https://github.com/raywenderlich/vapor-til/blob/master/cloud.yml), while I know for sure that also 4.2.0 is supported since I'm using it. If you think there are other versions in the middle we should add please comments are appreciated 😊

Also not sure: what is the default right now?