### PR TITLE
ADD - DATABASE_PORT to system setting keys

### DIFF
--- a/docs/configuration/vapor/custom-config.md
+++ b/docs/configuration/vapor/custom-config.md
@@ -71,6 +71,7 @@ DATABASE_USER # Database user
 DATABASE_PASSWORD # Database password
 DATABASE_DB # Database db
 DATABASE_HOSTNAME # Database hostname
+DATABASE_PORT # Database port
 REDIS_HOSTNAME # Redis server hostname if Redis is enabled
 REDIS_DATABASE # Redis server database if Redis is enabled
 PORT # Server port


### PR DESCRIPTION
When integrating mySQL database to my project I just grabbed the system files from this doc, since it was never mentioned there was a `DATABASE_PORT` variable, I was using the `PORT` variable instead, this lead me to face 503 errors.

I think it's important to mention this key here to eliminate confusion.